### PR TITLE
fixed pend_00_21_arbNJ og pend_00_21_boNJ

### DIFF
--- a/Arbeidskrav3.qmd
+++ b/Arbeidskrav3.qmd
@@ -48,48 +48,97 @@ Den første rammen viser, kode
 
 ```{r}
 #gererate knr
-knr <- paste(
-  "k",
-  c(1102, 1103, 1108, 1114, 1119, 1120, 1121,1122, 1124, 1127, 1129, 1130, 1133, 1141, 1142, 1144),
-  sep = ""
-  )
+# Må være en character vector for at SSB skal skjønne hva vi spør etter
+knr <- as.character(c(1102, 1103, 1108, 1114, 1119, 1120, 1121,1122, 1124, 
+                    1127, 1129, 1130, 1133, 1141, 1142, 1144))
+
 ```
+
+```{r}
+tid <- as.character(2000:2021)
+```
+
 
 ```{r}
 pend_00_21_ssb_arbNJ <- ApiData(
   urlToData = "03321",
-  #ArbstedKomm = knr,
+  ArbstedKomm = knr,
   Bokommuen = list('*'),
-  Tid = as.character(2000:2021)
+  Tid = tid
     )
-
-names(pend_00_21_ssb_arbNJ)[1] <- "desc_arbNJ"
 ```
 
 ```{r}
-pend_00_21_arbNJ <- pend_00_21_ssb_arbNJ$dataset %>%
-  left_join(pend_00_21_ssb_arbNJ$desc_arbNJ) %>%
-  mutate(akom_navn = 'municipality of work', bkom_navn = 'municipality of residence', akom = ArbstedKomm, bkom = Bokommuen, aar = year, pendlere = value) %>%
-  select(aar, akom, akom_navn, bkom, bkom_navn, pendlere
-) %>%
-#mangler rett på akom_navn og bkom_navn^
-as_tibble()
+names(pend_00_21_ssb_arbNJ)[1] <- "desc_arbNJ"
+```
 
+
+```{r}
+pend_00_21_arbNJ <- pend_00_21_ssb_arbNJ$dataset %>%
+# Neste vil gi en enorm matrise der alle kombinasjoner blir forsøkt generert
+#  left_join(pend_00_21_ssb_arbNJ$desc_arbNJ) %>%
+# Observasjonene i dataset og desc_ komponenten er ordnet i samme rekkefølge 
+#  så vi trenger bare hente variablen
+  rename(
+    aar = Tid
+  ) %>% 
+  mutate(
+    akom_navn = pend_00_21_ssb_arbNJ$desc_arbNJ$arbeidsstedskommune,
+    bkom_navn = pend_00_21_ssb_arbNJ$desc_arbNJ$bostedskommune,
+    akom = paste("k", ArbstedKomm, sep = ""),
+    bkom = paste("k", Bokommuen, sep = ""),
+    pendlere = value,
+  ) %>% 
+#  mutate(akom_navn = 'municipality of work', bkom_navn = 'municipality of residence', 
+#          akom = ArbstedKomm, bkom = Bokommuen, aar = year, pendlere = value) %>%
+  select(aar, akom, akom_navn, bkom, bkom_navn, pendlere) %>%
+  #mangler rett på akom_navn og bkom_navn
+  # nå bør ting virke
+  as_tibble()
+```
+
+```{r}
 print(pend_00_21_arbNJ, n = 5)
 ```
+
 
 ```{r}
 pend_00_21_ssb_boNJ <- ApiData(
   urlToData = "03321",
   ArbstedKomm = list('*'),
-  #Bokommuen = knr,
-  Tid = as.character(2000:2021)
+  Bokommuen = knr,
+  Tid = tid
     )
+```
 
+```{r}
 names(pend_00_21_ssb_boNJ)[1] <- "desc_boNJ"
 ```
 
 ```{r}
+# Lager pend_00_21_boNJ fra pend_00_21_ssb_boNJ
+pend_00_21_boNJ <- pend_00_21_ssb_boNJ$dataset %>% 
+  # Henter kommune navn fra desc_boNJ df
+  mutate(
+    akom_navn = pend_00_21_ssb_boNJ$desc_boNJ$arbeidsstedskommune,
+    bkom_navn = pend_00_21_ssb_boNJ$desc_boNJ$bostedskommune,
+    akom = paste("k", ArbstedKomm, sep = ""),
+    bkom = paste("k", Bokommuen, sep = "")
+  ) %>% 
+  # Endrer noen variabelnavn
+  rename(
+    aar = Tid,
+    pendlere = value 
+  )  %>%
+  select(aar, akom, akom_navn, bkom, bkom_navn, pendlere) %>% 
+  as_tibble()
+```
+
+
+```{r}
+#| eval: false
+#| echo: false
+# Denne virker ikke. Se ovenfor for kode
 pend_00_21_boNJ <- pend_00_21_ssb_boNJ$dataset %>%
   left_join(pend_00_21_ssb_boNJ$desc_boNJ) %>%
   mutate(akom_navn = 'municipality of work', bkom_navn = 'municipality of residence', akom = ArbstedKomm, bkom = Bokommuen, aar = year, pendlere = value) %>%
@@ -97,7 +146,9 @@ pend_00_21_boNJ <- pend_00_21_ssb_boNJ$dataset %>%
 )%>%
 #mangler rett på akom_navn og bkom_navn^
 as_tibble()
+```
 
+```{r}
 print(pend_00_21_boNJ, n = 5)
 ```
 
@@ -162,6 +213,10 @@ nye_bkom_navn, nye_akom_navn) |>
   select(aar, nye_akom, nye_akom_navn, nye_bkom, nye_bkom_navn, pendlere)
 ```
 
+# AG: Ned til her bør ting virke
+
+AG: Da har dere de to innledenen datasettene for hhv. bor og jobber på Nord-Jæren. Dere må så rekode akom, akom_navn, bkom og bkom_navn for å ta hensyn til kommunesammenslåingene. Se bruk av case_when i oppgaveteksten.
+
 ```{r}
 pend_00_21_boNJ_agg |>
   distinct(nye_bkom) |>
@@ -178,11 +233,12 @@ pend_00_21_boNJ_agg |>
 
 ```{r}
 pend_00_21_arbNJ <- pend_00_21_arbNJ |>
+  # For rename() er syntaksen nytt_navn = gammelt_navn
   rename(
-    akom = nye_akom,
-    akom_navn = nye_akom_navn,
-    bkom = nye_bkom,
-    bkom_navn = nye_bkom_navn
+    nye_akom = akom,
+    nye_akom_navn = akom_navn,
+    nye_bkom = bkom,
+    nye_bkom_navn = bkom_navn
   )
 ```
 
@@ -345,3 +401,8 @@ gjør resten imorgen
 ### 2015
 
 ### 2021
+
+```{r}
+#| echo: false
+# siste
+```


### PR DESCRIPTION
Har fikset innledende datasett. Den left_join() dere prøvde på var i ferd med å genere en enorm matrise med alle alternativene. Derfor feilmeldingen om ikke mer minne.Se oppgavesett for bruk av case_when() for å ta hensyn til kommunesammenslåingene